### PR TITLE
Feature implementation from commits fdc155d..24d4ddc

### DIFF
--- a/examples/aws-python-container/custom_dockerfile/Dockerfile
+++ b/examples/aws-python-container/custom_dockerfile/Dockerfile
@@ -5,9 +5,9 @@ ARG PYTHON_VERSION=3.11
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
 # # Ensure git is installed so we can install git based dependencies (such as sst)
-RUN yum update -y && \
-    yum install -y git gcc && \
-    yum clean all
+RUN dnf update -y && \
+    dnf install -y git gcc && \
+    dnf clean all
 
 # Install UV to manage your python runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv

--- a/examples/aws-realtime/sst.config.ts
+++ b/examples/aws-realtime/sst.config.ts
@@ -41,6 +41,7 @@ export default $config({
         SST_TOPIC: topic,
       },
       url: true,
+      link: [realtime],
     });
 
     return {

--- a/examples/internal/playground/functions/task/index.ts
+++ b/examples/internal/playground/functions/task/index.ts
@@ -4,13 +4,20 @@ import { task } from "/Users/frank/Sites/sst/sdk/js/src/aws/task";
 export const handler = async () => {
   const ret = await task.run(Resource.MyTask);
 
-  if (ret.tasks?.length) {
+  if (ret.response.tasks?.length) {
     return {
-      taskArn: ret.tasks[0].taskArn,
+      taskArn: ret.response.tasks[0].taskArn,
     };
   }
 
-  return ret;
+  return JSON.stringify(
+    {
+      ARN: ret.response.tasks[0]?.taskArn,
+      response: ret.response,
+    },
+    null,
+    2
+  );
 
   //const ret = await task.describe(Resource.MyTask, t);
 

--- a/examples/internal/playground/images/web/Dockerfile
+++ b/examples/internal/playground/images/web/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:18-bullseye-slim
-ARG SST_RESOURCE_MyBucket
 
 WORKDIR /app/
 
@@ -8,7 +7,8 @@ RUN npm install
 
 # Ensure linked resources are available at build time
 COPY build.mjs /app
-RUN node build.mjs
+RUN --mount=type=secret,id=SST_RESOURCE_MyBucket,env=SST_RESOURCE_MyBucket \
+  node build.mjs
 
 COPY index.mjs /app
 

--- a/examples/internal/playground/sst.config.ts
+++ b/examples/internal/playground/sst.config.ts
@@ -37,6 +37,7 @@ export default $config({
     //const bus = addBus();
     //const dynamo = addDynamo();
     //addOpenSearch();
+    //addStepFunction();
 
     return ret;
 
@@ -605,6 +606,20 @@ export default $config({
       ret.osUsername = os.username;
       ret.osPassword = os.password;
       return os;
+    }
+
+    function addStepFunction() {
+      const runTask = sst.aws.StepFunctions.ecsRunTask({
+        name: "MyTask",
+        task,
+        environment: {
+          FOO: "hello",
+        },
+      });
+      const stepFunction = new sst.aws.StepFunctions("MyStepFunction", {
+        definition: runTask,
+      });
+      return stepFunction;
     }
   },
 });

--- a/pkg/server/resource/aws-function-environment-update.go
+++ b/pkg/server/resource/aws-function-environment-update.go
@@ -16,23 +16,51 @@ type FunctionEnvironmentUpdateInputs struct {
 	Region       string            `json:"region"`
 }
 
-func (r *FunctionEnvironmentUpdate) Create(input *FunctionEnvironmentUpdateInputs, output *CreateResult[struct{}]) error {
+type FunctionEnvironmentUpdateOutputs struct {
+	Updated bool `json:"updated"`
+}
+
+func (r *FunctionEnvironmentUpdate) Create(input *FunctionEnvironmentUpdateInputs, output *CreateResult[FunctionEnvironmentUpdateOutputs]) error {
 	if err := r.updateEnvironment(input); err != nil {
 		return err
 	}
 
-	*output = CreateResult[struct{}]{
+	*output = CreateResult[FunctionEnvironmentUpdateOutputs]{
 		ID: input.FunctionName,
+		Outs: FunctionEnvironmentUpdateOutputs{
+			Updated: true,
+		},
 	}
 	return nil
 }
 
-func (r *FunctionEnvironmentUpdate) Update(input *UpdateInput[FunctionEnvironmentUpdateInputs, struct{}], output *UpdateResult[struct{}]) error {
+func (r *FunctionEnvironmentUpdate) Update(input *UpdateInput[FunctionEnvironmentUpdateInputs, FunctionEnvironmentUpdateOutputs], output *UpdateResult[FunctionEnvironmentUpdateOutputs]) error {
 	if err := r.updateEnvironment(&input.News); err != nil {
 		return err
 	}
 
-	*output = UpdateResult[struct{}]{}
+	*output = UpdateResult[FunctionEnvironmentUpdateOutputs]{
+		Outs: FunctionEnvironmentUpdateOutputs{
+			Updated: true,
+		},
+	}
+	return nil
+}
+
+func (r *FunctionEnvironmentUpdate) Read(input *ReadInput[FunctionEnvironmentUpdateInputs], output *ReadResult[FunctionEnvironmentUpdateOutputs]) error {
+	*output = ReadResult[FunctionEnvironmentUpdateOutputs]{
+		ID: input.ID,
+		Outs: FunctionEnvironmentUpdateOutputs{
+			Updated: false,
+		},
+	}
+	return nil
+}
+
+func (r *FunctionEnvironmentUpdate) Diff(input *DiffInput[FunctionEnvironmentUpdateInputs, FunctionEnvironmentUpdateOutputs], output *DiffResult) error {
+	*output = DiffResult{
+		Changes: input.Olds.Updated != true,
+	}
 	return nil
 }
 

--- a/pkg/server/resource/resource.go
+++ b/pkg/server/resource/resource.go
@@ -19,9 +19,25 @@ type ReadResult[T any] struct {
 	Outs T      `json:"outs"`
 }
 
+type DiffInput[N any, O any] struct {
+	ID   string `json:"id"`
+	News N      `json:"news"`
+	Olds O      `json:"olds"`
+}
+
+type DiffResult struct {
+	Changes bool `json:"changes"`
+}
+
 type CreateResult[T any] struct {
 	ID   string `json:"id"`
 	Outs T      `json:"outs"`
+}
+
+type UpdateInput[N any, O any] struct {
+	ID   string `json:"id"`
+	News N      `json:"news"`
+	Olds O      `json:"olds"`
 }
 
 type UpdateResult[T any] struct {
@@ -31,12 +47,6 @@ type UpdateResult[T any] struct {
 type DeleteInput[T any] struct {
 	ID   string `json:"id"`
 	Outs T      `json:"outs"`
-}
-
-type UpdateInput[N any, O any] struct {
-	ID   string `json:"id"`
-	News N      `json:"news"`
-	Olds O      `json:"olds"`
 }
 
 type AwsResource struct {

--- a/pkg/types/typescript/typescript.go
+++ b/pkg/types/typescript/typescript.go
@@ -104,7 +104,7 @@ func Generate(root string, links common.Links) error {
 		}
 
 		rel, err := filepath.Rel(filepath.Dir(envPath), rootEnv)
-		envFile.WriteString("/// <reference path=\"" + rel + "\" />\n")
+		envFile.WriteString("/// <reference path=\"" + filepath.ToSlash(rel) + "\" />\n")
 	}
 
 	return nil

--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -1031,10 +1031,8 @@ export function createTaskDefinition(
             {
               context: { location: contextPath },
               dockerfile: { location: dockerfilePath },
-              buildArgs: linkEnvs.apply((linkEnvs) => ({
-                ...containerImage.args,
-                ...linkEnvs,
-              })),
+              buildArgs: containerImage.args,
+              secrets: linkEnvs,
               target: container.image.target,
               platforms: [container.image.platform],
               tags: [container.name, ...(container.image.tags ?? [])].map(

--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -11,7 +11,7 @@ import { isALteB } from "../../util/compare-semver.js";
 import { Plan, SsrSite, SsrSiteArgs } from "./ssr-site.js";
 import { Bucket } from "./bucket.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.6.2";
+const DEFAULT_OPEN_NEXT_VERSION = "3.6.4";
 
 type BaseFunction = {
   handler: string;

--- a/platform/src/components/aws/realtime.ts
+++ b/platform/src/components/aws/realtime.ts
@@ -6,6 +6,7 @@ import { Function, FunctionArgs, FunctionArn } from "./function";
 import { hashStringToPrettyString, logicalName } from "../naming";
 import { RealtimeLambdaSubscriber } from "./realtime-lambda-subscriber";
 import { iot, lambda } from "@pulumi/aws";
+import { permission } from "./permission";
 
 export interface RealtimeArgs {
   /**
@@ -175,9 +176,10 @@ export class Realtime extends Component implements Link.Linkable {
     createPermission();
 
     this.constructorOpts = opts;
-    this.iotEndpoint = iot.getEndpointOutput({
-      endpointType: "iot:Data-ATS",
-    }, { parent }).endpointAddress;
+    this.iotEndpoint = iot.getEndpointOutput(
+      { endpointType: "iot:Data-ATS" },
+      { parent },
+    ).endpointAddress;
     this.constructorName = name;
     this.authHadler = authHadler;
     this.iotAuthorizer = iotAuthorizer;
@@ -328,6 +330,12 @@ export class Realtime extends Component implements Link.Linkable {
         endpoint: this.endpoint,
         authorizer: this.authorizer,
       },
+      include: [
+        permission({
+          actions: ["iot:Publish"],
+          resources: ["*"],
+        }),
+      ],
     };
   }
 }

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1709,7 +1709,7 @@ async function handler(event) {
   /**
    * Add a route to a destination URL.
    *
-   * @param pattern The path pattern to match for this route.
+   * @param pattern The path prefix to match for this route.
    * @param url The destination URL to route matching requests to.
    * @param args Configure the route.
    *
@@ -1783,7 +1783,7 @@ async function handler(event) {
   /**
    * Add a route to an S3 bucket.
    *
-   * @param pattern The path pattern to match for this route.
+   * @param pattern The path prefix to match for this route.
    * @param bucket The S3 bucket to route matching requests to.
    * @param args Configure the route.
    *
@@ -1865,7 +1865,7 @@ async function handler(event) {
   /**
    * Add a route to a frontend or static site.
    *
-   * @param pattern The path pattern to match for this route.
+   * @param pattern The path prefix to match for this route.
    * @param site The frontend or static site to route matching requests to.
    *
    * @deprecated The `routeSite` function has been deprecated. Set the `route` on the

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1717,11 +1717,11 @@ async function handler(event) {
    *
    * You can match a route based on:
    *
-   * - A path like `/api`
+   * - A path prefix like `/api`
    * - A domain pattern like `api.example.com`
    * - A combined pattern like `dev.example.com/api`
    *
-   * For example, to match a path.
+   * For example, to match a path prefix.
    *
    * ```ts title="sst.config.ts"
    * router.route("/api", "https://api.example.com");
@@ -1799,11 +1799,11 @@ async function handler(event) {
    *
    * You can match a pattern and route to it based on:
    *
-   * - A path like `/api`
+   * - A path prefix like `/api`
    * - A domain pattern like `api.example.com`
    * - A combined pattern like `dev.example.com/api`
    *
-   * For example, to match a path.
+   * For example, to match a path prefix.
    *
    * ```ts title="sst.config.ts"
    * router.routeBucket("/files", bucket);

--- a/platform/src/components/aws/step-functions.ts
+++ b/platform/src/components/aws/step-functions.ts
@@ -685,9 +685,13 @@ export class StepFunctions extends Component implements Link.Linkable {
         TaskDefinition: args.task.taskDefinition,
         LaunchType: "FARGATE",
         NetworkConfiguration: {
-          Subnets: args.task.subnets,
-          SecurityGroups: args.task.securityGroups,
-          AssignPublicIp: args.task.assignPublicIp,
+          AwsvpcConfiguration: {
+            Subnets: args.task.subnets,
+            SecurityGroups: args.task.securityGroups,
+            AssignPublicIp: args.task.assignPublicIp.apply((v) =>
+              v ? "ENABLED" : "DISABLED",
+            ),
+          },
         },
         Overrides:
           args.environment &&
@@ -705,7 +709,14 @@ export class StepFunctions extends Component implements Link.Linkable {
       permissions: [
         {
           actions: ["ecs:RunTask"],
-          resources: [args.task.cluster],
+          resources: [args.task.nodes.taskDefinition.arn],
+        },
+        {
+          actions: ["iam:PassRole"],
+          resources: [
+            args.task.nodes.executionRole.arn,
+            args.task.nodes.taskRole.arn,
+          ],
         },
       ],
     });

--- a/platform/src/components/aws/step-functions/state.ts
+++ b/platform/src/components/aws/step-functions/state.ts
@@ -77,7 +77,7 @@ export interface RetryArgs {
    * @default `2`
    */
   backoffRate?: number;
-};
+}
 
 export interface CatchArgs {
   /**
@@ -86,7 +86,7 @@ export interface CatchArgs {
    * @default `["States.ALL"]`
    */
   errors?: string[];
-};
+}
 
 export interface StateArgs {
   /**
@@ -180,7 +180,7 @@ export abstract class State {
   protected _retries?: RetryArgs[];
   protected _catches?: { next: State; props: CatchArgs }[];
 
-  constructor(protected args: StateArgs) { }
+  constructor(protected args: StateArgs) {}
 
   protected addChildGraph<T extends State>(state: T): T {
     if (state._parentGraphState)
@@ -219,7 +219,7 @@ export abstract class State {
   protected addCatch(state: State, args: CatchArgs = {}) {
     this._catches = this._catches || [];
     this._catches.push({
-      next: state,
+      next: state.getHead(),
       props: {
         errors: args.errors ?? ["States.ALL"],
       },

--- a/platform/src/components/rpc/rpc.ts
+++ b/platform/src/components/rpc/rpc.ts
@@ -99,5 +99,12 @@ export module rpc {
         throw ex;
       });
     }
+
+    async diff(id: string, olds: any, news: any): Promise<dynamic.DiffResult> {
+      return call(this.name("Diff"), { id, olds, news }).catch((ex) => {
+        if (ex instanceof MethodNotFoundError) return { id, olds, news };
+        throw ex;
+      });
+    }
   }
 }

--- a/www/src/content/docs/docs/start/aws/nextjs.mdx
+++ b/www/src/content/docs/docs/start/aws/nextjs.mdx
@@ -500,10 +500,12 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# If static pages need linked resources
-# ARG SST_RESOURCE_MyResource
-
+# If static pages do not need linked resources
 RUN npm run build
+
+# If static pages need linked resources
+# RUN --mount=type=secret,id=SST_RESOURCE_MyResource,env=SST_RESOURCE_MyResource \
+#   npm run build
 
 # Stage 3: Production server
 FROM base AS runner
@@ -525,7 +527,7 @@ You need to be running [Docker Desktop](https://www.docker.com/products/docker-d
 If your Next.js app is building static pages that need linked resources, you can need to declare them in your `Dockerfile`. For example, if we need the linked `MyBucket` component from above.
 
 ```dockerfile
-ARG SST_RESOURCE_MyBucket
+RUN --mount=type=secret,id=SST_RESOURCE_MyBucket,env=SST_RESOURCE_MyBucket npm run build
 ```
 
 You'll need to do this for each linked resource.


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `fdc155d..24d4ddc`
**Files Changed:** 18 (15 programming files)
**Programming Ratio:** 83.3%

**Commits included:**
- Bump OpenNext to v3.6.4 (#5839)
- docs: Replace yum with dnf (#5848)
- fix: normalize path separators in TypeScript reference generation (#5842)
- Example: sync playground
- Cluster: use docker secrets to pass link values
- Router: update docs to clarify route path takes prefix
- Router: update docs to clarify route path takes prefix
- Examples: sync playground
- StepFunctions: fix ecsRunTask payload format
- Realtime: grant iot permissions when linked
... and 5 more commits